### PR TITLE
Enable and modify spotify docker maven plugin

### DIFF
--- a/docker/global-apim/pom.xml
+++ b/docker/global-apim/pom.xml
@@ -158,24 +158,23 @@
                 </executions>
             </plugin>
 
-            <!-- TODO: Temporarily comment out Docker build for Release 0.1.0 -->
             <!--Build Docker image-->
-            <!--<plugin>-->
-                <!--<groupId>com.spotify</groupId>-->
-                <!--<artifactId>dockerfile-maven-plugin</artifactId>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>default</id>-->
-                        <!--<goals>-->
-                            <!--<goal>build</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<repository>${docker.repo.name}/wso2am</repository>-->
-                            <!--<tag>${docker.image.tag}</tag>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <repository>${docker.repo.name}/wso2am</repository>
+                            <tag>${docker.image.tag}</tag>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/docker/global-apim/pom.xml
+++ b/docker/global-apim/pom.xml
@@ -137,7 +137,7 @@
                     </execution>
                     <execution>
                         <id>copy-sts-web-app</id>
-                        <phase>package</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>

--- a/docker/microgateway/init-container/pom.xml
+++ b/docker/microgateway/init-container/pom.xml
@@ -60,24 +60,23 @@
                 </executions>
             </plugin>
 
-            <!-- TODO: Temporarily comment out Docker build for Release 0.1.0 -->
             <!--Build Docker image-->
-            <!--<plugin>-->
-                <!--<groupId>com.spotify</groupId>-->
-                <!--<artifactId>dockerfile-maven-plugin</artifactId>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>default</id>-->
-                        <!--<goals>-->
-                            <!--<goal>build</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<repository>${docker.repo.name}/cell-gateway-init</repository>-->
-                            <!--<tag>${docker.image.tag}</tag>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <repository>${docker.repo.name}/cell-gateway-init</repository>
+                            <tag>${docker.image.tag}</tag>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/docker/microgateway/microgateway-container/pom.xml
+++ b/docker/microgateway/microgateway-container/pom.xml
@@ -34,24 +34,23 @@
 
     <build>
         <plugins>
-            <!-- TODO: Temporarily comment out Docker build for Release 0.1.0 -->
             <!--Build Docker image-->
-            <!--<plugin>-->
-                <!--<groupId>com.spotify</groupId>-->
-                <!--<artifactId>dockerfile-maven-plugin</artifactId>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>default</id>-->
-                        <!--<goals>-->
-                            <!--<goal>build</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<repository>${docker.repo.name}/cell-gateway</repository>-->
-                            <!--<tag>${docker.image.tag}</tag>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <repository>${docker.repo.name}/cell-gateway</repository>
+                            <tag>${docker.image.tag}</tag>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Purpose
> This was disabled to avoid Jenkins build failure. It can be disabled using -Ddockerfile.skip with maven install. Therefore, the plugin can be enabled.
