### PR TITLE
Fix bug in creating Swagger Definition from Cell Yaml

### DIFF
--- a/components/gateway/io.cellery.cell.gateway.initializer/src/main/java/io/cellery/cell/gateway/initializer/UpdateManager.java
+++ b/components/gateway/io.cellery.cell.gateway.initializer/src/main/java/io/cellery/cell/gateway/initializer/UpdateManager.java
@@ -518,7 +518,7 @@ public class UpdateManager {
     private static Map<String, Path> createAPIResources(API api) {
         Map<String, Path> pathMap = new HashMap<>();
         for (ApiDefinition definition : api.getDefinitions()) {
-            Path path = new Path();
+            Path path = pathMap.computeIfAbsent(definition.getPath(), (key) -> new Path());
             Operation op = new Operation();
 
             Map<String, Response> resMap = new HashMap<>();
@@ -536,10 +536,15 @@ public class UpdateManager {
                 case Constants.JsonParamNames.POST:
                     path.setPost(op);
                     break;
+                case Constants.JsonParamNames.PUT:
+                    path.setPut(op);
+                    break;
+                case Constants.JsonParamNames.DELETE:
+                    path.setDelete(op);
+                    break;
                 default:
                     log.error("HTTP Method not implemented");
             }
-            pathMap.put(definition.getPath(), path);
         }
         return pathMap;
     }


### PR DESCRIPTION
## Purpose
> Fix bug in creating swagger definition from the Cell Definition

## Goals
> Allow to have more than a single method for a particular path in the swagger definition generated in the Cell Gateway Init container.

## Approach
> Fix bug in Swagger Definition generation in the Cell Gateway Init Container

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A