### PR TITLE
Add permission for the Stream Processor to watch for K8s pods

### DIFF
--- a/installer/k8s-artefacts/observability/sp/sp-worker.yaml
+++ b/installer/k8s-artefacts/observability/sp/sp-worker.yaml
@@ -138,6 +138,7 @@ rules:
       - pods
     verbs:
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Purpose
> Add permission for SP Worker to get a single pod from API Server

## Goals
> Allow SP Worker to watch Pods.

## Approach
> The watch verb is added to the clusterrole's pod resource.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A