### PR TITLE
Fix #mesh-observability/51 by removing unwanted filters in the Pod Metrics Dashboards

### DIFF
--- a/installer/k8s-artefacts/observability/grafana/dashboards/default/pod-metrics.json
+++ b/installer/k8s-artefacts/observability/grafana/dashboards/default/pod-metrics.json
@@ -78,7 +78,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",pod_name=~\"^$pod$\"}) by (pod_name)",
+          "expr": "sum (container_memory_working_set_bytes{image!=\"\",pod_name=~\"^$pod$\"}) by (pod_name)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -190,7 +190,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",pod_name=~\"^$pod$\"}[1m])) by (pod_name)",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",pod_name=~\"^$pod$\"}[1m])) by (pod_name)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -303,7 +303,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",pod_name=~\"^$pod$\"}[1m])) by (pod_name)",
+          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",pod_name=~\"^$pod$\"}[1m])) by (pod_name)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -313,7 +313,7 @@
           "step": 10
         },
         {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",pod_name=~\"^$pod$\"}[1m])) by (pod_name)",
+          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",pod_name=~\"^$pod$\"}[1m])) by (pod_name)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,


### PR DESCRIPTION
## Purpose
> Fix wso2-cellery/mesh-observability#51 by removing unwanted filters in the PromQL queries in the Grafana Dashboards

## Goals
> Allow the users to view Pod metrics of a Cellery Runtime running on top of GCP.

## Approach
> The unwanted filer `name=~"^k8s_.*"`. This was valid in a local setup. However in GCP, the names were different causing the metrics to be not available.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A