### PR TITLE
Add permissions for watching composites by Stream Processor

### DIFF
--- a/installer/k8s-artefacts/observability/sp/sp-worker.yaml
+++ b/installer/k8s-artefacts/observability/sp/sp-worker.yaml
@@ -154,6 +154,7 @@ rules:
       - mesh.cellery.io
     resources:
       - cells
+      - composites
     verbs:
       - watch
 ---


### PR DESCRIPTION
## Purpose
> Add permissions for watching composites by Stream Processor.

## Goals
> Add permissions for watching composites by Stream Processor.

## Approach
> Add permissions for watching composites by Stream Processor.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Cellery 0.4.0-SNAPSHOT - Local Distribution
 
## Learning
> N/A