### PR TITLE
Change Load balancer type to cluster IP in istio-ingressgateway

### DIFF
--- a/installer/k8s-artefacts/system/istio-demo-cellery.yaml
+++ b/installer/k8s-artefacts/system/istio-demo-cellery.yaml
@@ -16345,7 +16345,6 @@ metadata:
     app: istio-ingressgateway
     istio: ingressgateway
 spec:
-  type: LoadBalancer
   selector:
     release: istio
     app: istio-ingressgateway
@@ -16357,16 +16356,13 @@ spec:
     targetPort: 15020
   -
     name: http2
-    nodePort: 31380
     port: 80
     targetPort: 80
   -
     name: https
-    nodePort: 31390
     port: 443
   -
     name: tcp
-    nodePort: 31400
     port: 31400
   -
     name: https-kiali


### PR DESCRIPTION
## Purpose
> Change Load balancer type to cluster IP in istio-ingress gateway.
