### PR TITLE
Modify nginx config maps to set header to enforce trace reporting

### DIFF
--- a/installer/k8s-artefacts/system/mandatory.yaml
+++ b/installer/k8s-artefacts/system/mandatory.yaml
@@ -77,6 +77,20 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
+data:
+  proxy-set-headers: ingress-nginx/custom-headers
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: custom-headers
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+data:
+  x-b3-sampled: "1"   # Used to enforce trace reporting in all the services in the cluster (Observability)
 ---
 
 kind: ConfigMap


### PR DESCRIPTION
## Purpose
> Modify nginx config maps to set header to enforce trace reporting.

## Goals
> Modify nginx config maps to set header to enforce trace reporting.

## Approach
> Modify nginx config maps to set header to enforce trace reporting. The x-b3-sampled header is added to all the requests so that all the downstream cluster would report all their traces to SP.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A